### PR TITLE
Fix visualization bug and add rotation unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ project_root/
 │   │   ├── imagesTs/          # 7 test CT volumes
 │   │   └── dataset.json       # nnU-Net metadata
 │
-├── preprocess/
-│   ├── convert_dicom_to_nifti.py
-│   └── ...
-│
-├── results/
-│   └── ...                    # Output predictions and metrics
-│
+├── interpolate.py             # Utility for interpolation experiments
+├── nnUNet_preprocessed/       # Preprocessed volumes ready for nnU-Net
+├── nnUNet_results/            # Trained nnU-Net checkpoints and logs
+├── predictions/               # Sample predictions exported from nnU-Net
+├── predictions_eyeball_1000/  # Additional prediction snapshots
+├── rotate.py                  # Standalone rotation/visualization script
+├── streamlit_pipeline.py      # Streamlit application entry point
 └── README.md
 ```
 
@@ -105,7 +105,7 @@ After model inference, we perform post-processing to extract meaningful anatomic
 ---
 
 ## 📊 Train Results
-### Trained 1000 epoch in RTX4090 setting and achieved Dice score of 0.81 in validation set. 
+### Trained 1000 epochs in RTX4090 setting and achieved Dice score of 0.81 in validation set.
 <img width="402" alt="Image" src="https://github.com/user-attachments/assets/ec25fdbb-ffe3-4c3f-a1a8-ed5718edbbdf" />
 
 ### Below is the image of a rotated Brain CT, using the predicted eye mask. 

--- a/rotate.py
+++ b/rotate.py
@@ -1,4 +1,3 @@
-import nibabel as nib
 import numpy as np
 from scipy import ndimage
 from skimage.measure import label, regionprops
@@ -104,6 +103,7 @@ def save_single_slice_comparison(ct_data, rotated_ct, save_path='slice_compariso
     print(f"단일 슬라이스 비교 이미지 저장됨: {save_path}")
 
 def main(ct_path, mask_path, output_ct_path, output_mask_path):
+    import nibabel as nib
     print("=== 눈 정렬을 위한 CT 회전 ===\n")
 
     print("1. 데이터 로드 중...")

--- a/streamlit_pipeline.py
+++ b/streamlit_pipeline.py
@@ -214,9 +214,6 @@ def create_visualization(ct_data, mask_data, rotated_ct, rotated_mask, angle):
     # 중간 슬라이스 선택
     center_slice = mask_slices[len(mask_slices)//2]
     
-    fig, axes = plt.subplots
-
-# create_visualization 함수 계속
     fig, axes = plt.subplots(1, 4, figsize=(16, 4))
     
     # 원본 CT

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -1,0 +1,41 @@
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from rotate import calculate_rotation_angle, find_eye_centers
+
+
+def test_find_eye_centers_returns_sorted_centers():
+    mask = np.zeros((3, 5, 5), dtype=int)
+    mask[1, 1:3, 1:3] = 1  # left eye blob
+    mask[1, 1:3, 4:5] = 1  # right eye blob separated by a zero column
+
+    centers = find_eye_centers(mask)
+
+    assert len(centers) == 2
+    assert centers[0][0] < centers[1][0]
+    # centroids should be roughly at the center of each blob
+    assert centers[0][0] == pytest.approx(1.5)
+    assert centers[1][0] == pytest.approx(4.0)
+    assert centers[0][1] == pytest.approx(1.5)
+    assert centers[1][1] == pytest.approx(1.5)
+
+
+def test_calculate_rotation_angle_with_two_centers():
+    centers = [(0.0, 0.0), (1.0, 1.0)]
+
+    angle = calculate_rotation_angle(centers)
+
+    assert angle == pytest.approx(45.0)
+
+
+def test_calculate_rotation_angle_with_single_center_returns_zero():
+    angle = calculate_rotation_angle([(2.0, 3.0)])
+
+    assert angle == 0


### PR DESCRIPTION
## Summary
- correct the README folder overview and fix a grammar typo in the training results section
- move the nibabel import inside the CLI entrypoint so helper functions can be imported without optional dependencies
- remove the stray plt.subplots reference in the Streamlit visualization routine and add focused unit tests for rotation helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbc1c705c4832bbab969307c1a12e2